### PR TITLE
fix: Restore Prisma mock file to fix test execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,5 +89,5 @@ scripts/
 .swc/
 .cache/
 .parcel-cache/
-__mocks__/
+# __mocks__/ # Needed for Prisma mock
 .env

--- a/__mocks__/@prisma/client.js
+++ b/__mocks__/@prisma/client.js
@@ -1,0 +1,24 @@
+// Mock for @prisma/client
+module.exports = {
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    organisations: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    migrations: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    migration_sessions: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    $disconnect: jest.fn(),
+  })),
+};


### PR DESCRIPTION
## Summary

Tests are failing on staging branch due to missing Prisma mock file.

## Changes
- Remove `__mocks__/` from .gitignore
- Add `@prisma/client` mock file

## Issue
Tests were failing with:
```
Configuration error:
Could not locate module @prisma/client mapped as:
/__mocks__/@prisma/client.js
```

## Test Results
After this fix, tests can execute (though some still fail due to code changes - those need separate fixes).

This is a critical fix to restore test execution on the staging branch.