### PR TITLE
fix: Scope paycode external ID validation to selected records only

### DIFF
--- a/src/lib/migration/templates/definitions/payroll/pay-codes.template.ts
+++ b/src/lib/migration/templates/definitions/payroll/pay-codes.template.ts
@@ -95,7 +95,7 @@ export const payCodesTemplate: MigrationTemplate = {
                     {
                         checkName: "external-id-check",
                         description: "Check if external ID exists",
-                        validationQuery: "SELECT Id FROM tc9_pr__Pay_Code__c WHERE {externalIdField} = null",
+                        validationQuery: "SELECT Id FROM tc9_pr__Pay_Code__c WHERE Id IN ({selectedRecordIds}) AND {externalIdField} = null",
                         expectedResult: "empty",
                         errorMessage: "Pay Code records missing external ID",
                         severity: "warning"


### PR DESCRIPTION
## Summary
- Fixed external ID validation in pay-codes template to only check selected records
- Prevents false validation failures when migrating specific records

## Problem
The `external-id-check` validation was checking ALL pay codes in the source org instead of just the selected records. This caused migrations to fail even when the selected record had a valid external ID, because the check would find other unrelated pay codes without external IDs.

## Solution
Updated the validation query to include the `{selectedRecordIds}` placeholder:
```sql
-- Before:
SELECT Id FROM tc9_pr__Pay_Code__c WHERE {externalIdField} = null

-- After:
SELECT Id FROM tc9_pr__Pay_Code__c WHERE Id IN ({selectedRecordIds}) AND {externalIdField} = null
```

This ensures the validation only checks the records being migrated, consistent with other templates like interpretation-rules.

## Test Plan
- [x] Linting passes
- [x] Type checking passes
- [x] Unit tests pass
- [ ] Manual test: Validate a pay code migration with selected record that has external ID
- [ ] Manual test: Confirm validation now passes for records with external IDs
- [ ] Manual test: Confirm validation still fails for selected records without external IDs

Fixes #142

🤖 Generated with [Claude Code](https://claude.ai/code)