### PR TITLE
fix: Remove email and page display from feedback form

### DIFF
--- a/src/components/features/feedback/FeedbackDialog.tsx
+++ b/src/components/features/feedback/FeedbackDialog.tsx
@@ -296,16 +296,6 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
                   <AlertDescription>{error}</AlertDescription>
                 </Alert>
               )}
-
-              <div className="text-xs text-muted-foreground">
-                <p>Your email: {session?.user?.email || "Not logged in"}</p>
-                <p>
-                  Current page:{" "}
-                  {typeof window !== "undefined"
-                    ? window.location.pathname
-                    : ""}
-                </p>
-              </div>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Removed the display of user email and current page URL from the feedback dialog
- Backend functionality remains unchanged - these values are still sent with feedback submissions
- Closes #174

## Changes
- Removed lines 300-308 from `FeedbackDialog.tsx` containing the email and page display section
- No backend or API changes required

## Test plan
- [x] TypeScript type checking passes
- [x] ESLint validation passes (no new errors)
- [x] Application builds successfully
- [ ] Manual testing: Submit feedback and verify it still works correctly
- [ ] Verify email and URL are still included in backend payload

🤖 Generated with [Claude Code](https://claude.ai/code)